### PR TITLE
Correction to SMBH Etotal.P calculation

### DIFF
--- a/src/cmc/cmc_utils.c
+++ b/src/cmc/cmc_utils.c
@@ -620,14 +620,14 @@ void ComputeEnergy(void)
 	//MPI: Calculating these variables on each processor
 	for (i=1; i<=mpiEnd-mpiBegin+1; i++) {
 		j = get_global_idx(i);
-		buf_reduce[1] += 0.5 * (sqr(star[i].vr) + sqr(star[i].vt)) * star_m[j] / clus.N_STAR;
-		buf_reduce[2] += star_phi[j] * star_m[j] / clus.N_STAR;
-		buf_reduce[2] += phi0 * cenma.m*madhoc/ clus.N_STAR;
+		buf_reduce[1] += 0.5 * (sqr(star[i].vr) + sqr(star[i].vt)) * star_m[j]*madhoc;
+		buf_reduce[2] += star_phi[j] * star_m[j]*madhoc;
+		buf_reduce[2] += phi0 * cenma.m*madhoc / clus.N_MAX;
 
 		if (star[i].binind == 0) {
 			buf_reduce[3] += star[i].Eint;
 		} else if (binary[star[i].binind].inuse) {
-			buf_reduce[4] += -(binary[star[i].binind].m1/clus.N_STAR) * (binary[star[i].binind].m2/clus.N_STAR) / 
+			buf_reduce[4] += -(binary[star[i].binind].m1*madhoc) * (binary[star[i].binind].m2*madhoc) / 
 				(2.0 * binary[star[i].binind].a);
 			buf_reduce[3] += binary[star[i].binind].Eint1 + binary[star[i].binind].Eint2;
 		}


### PR DESCRIPTION
The previous version had the correct expression for the SMBH buf_reduce[2] contribution (to keep up with the double counting in the non-SMBH calculation).  The issue was that because this was included in the loop over all objects it had to be divided by the number of objects (clus.N_MAX), but this operation was strikingly similar to the mass unit conversions in the previous lines (/ clus.N_STAR); it would appear that this similarity was what caused clus.N_STAR to be used instead, which meant the second buf_reduce[2]+= line was adding something too small by a multiplicative factor of clus.N_MAX/clus.N_STAR.  As the clusters lost objects, this bug eventually caused ComputeEnergy to incorrectly yield Etotal.tot>0, terminating the run.

tl;dr: Using the wrong global variable caused the diagnostic ComputeEnergy to think the cluster was unbound.  This was fixed, along with switching out the appropriate "/ clus.N_STAR"s for "* madhoc"s to hopefully avoid this error in the future.